### PR TITLE
Add a new mode, `json`, which supports SPI image labeling.  It's an alternative to `label` mode, but outputs labels into a json file.

### DIFF
--- a/psocake/gui.py
+++ b/psocake/gui.py
@@ -120,31 +120,37 @@ class Window(QtGui.QMainWindow):
                     # Fetch label from the GUI user prompt
                     label_str, is_ok = QtGui.QInputDialog.getText(self, "Enter new label", "Enter new label")
 
-                    # Record the label
-                    self.eventDocument[ex.eventNumber] = label_str
-                    print(self.eventDocument)
+                    # Process the OK event
+                    if is_ok:
+                        # Record the label
+                        self.eventDocument[ex.eventNumber] = label_str
+                        ## print(self.eventDocument)
 
-                    # Report it to terminal
-                    record = "{experimentName}.{runNumber:04d}.{eventNumber:06d}".format( experimentName = ex.experimentName,
-                                                                                          runNumber      = ex.runNumber     ,
-                                                                                          eventNumber    = ex.eventNumber )
-                    print("{record} has a label: {label_str}.".format(record = record, label_str = label_str))
+                        # Report it to terminal
+                        record = "{experimentName}.{runNumber:04d}.{eventNumber:06d}".format( experimentName = ex.experimentName,
+                                                                                              runNumber      = ex.runNumber     ,
+                                                                                              eventNumber    = ex.eventNumber )
+                        print("{record} has a label: {label_str}.".format(record = record, label_str = label_str))
 
                 # Quick dialog to go to a specific event by event number
                 if event.key() == QtCore.Qt.Key_G:
                     # Fetch event number from the GUI user prompt
                     eventNumber, is_ok = QtGui.QInputDialog.getText(self, "Enter new event number", "Enter new event number")
-                    eventNumber = int(eventNumber)
 
-                    # Let event number bound between 0 and event total
-                    eventNumber = min( max( 0, eventNumber ), ex.exp.eventTotal - 1 )
+                    # Process the OK event
+                    if is_ok:
+                        # Format event number into integer
+                        eventNumber = int(eventNumber)
 
-                    # Update image and metadata
-                    ex.calib, ex.data = ex.img.getDetImage(eventNumber)
-                    ex.img.win.setImage(ex.data,autoRange=False,autoLevels=False,autoHistogramRange=False)
-                    ex.exp.p.param(ex.exp.exp_grp,ex.exp.exp_evt_str).setValue(eventNumber)
-                    if 'label' in ex.args.mode:
-                        ex.labeling.updateText()
+                        # Let event number bound between 0 and event total
+                        eventNumber = min(max(0, eventNumber), ex.exp.eventTotal-1)
+
+                        # Update image and metadata
+                        ex.calib, ex.data = ex.img.getDetImage(eventNumber)
+                        ex.img.win.setImage(ex.data,autoRange=False,autoLevels=False,autoHistogramRange=False)
+                        ex.exp.p.param(ex.exp.exp_grp,ex.exp.exp_evt_str).setValue(eventNumber)
+                        if 'label' in ex.args.mode:
+                            ex.labeling.updateText()
 
 
 

--- a/psocake/gui.py
+++ b/psocake/gui.py
@@ -130,6 +130,23 @@ class Window(QtGui.QMainWindow):
                                                                                           eventNumber    = ex.eventNumber )
                     print("{record} has a label: {label_str}.".format(record = record, label_str = label_str))
 
+                # Quick dialog to go to a specific event by event number
+                if event.key() == QtCore.Qt.Key_G:
+                    # Fetch event number from the GUI user prompt
+                    eventNumber, is_ok = QtGui.QInputDialog.getText(self, "Enter new event number", "Enter new event number")
+                    eventNumber = int(eventNumber)
+
+                    # Let event number bound between 0 and event total
+                    eventNumber = min( max( 0, eventNumber ), ex.exp.eventTotal - 1 )
+
+                    # Update image and metadata
+                    ex.calib, ex.data = ex.img.getDetImage(eventNumber)
+                    ex.img.win.setImage(ex.data,autoRange=False,autoLevels=False,autoHistogramRange=False)
+                    ex.exp.p.param(ex.exp.exp_grp,ex.exp.exp_evt_str).setValue(eventNumber)
+                    if 'label' in ex.args.mode:
+                        ex.labeling.updateText()
+
+
 
 class MainFrame(QtGui.QWidget):
     """

--- a/psocake/gui.py
+++ b/psocake/gui.py
@@ -100,6 +100,18 @@ class Window(QtGui.QMainWindow):
             goto_dict  = { QtCore.Qt.Key_N : "next", 
                            QtCore.Qt.Key_P : "prev", }
 
+            # Load the existing .label.json
+            # Check if a file of labels have existed
+            basename = '{experimentName}_{runNumber:04d}'.format( experimentName = ex.experimentName,
+                                                                  runNumber      = ex.runNumber )
+            fl_label = '{basename}.label.json'.format( basename = basename )
+            path_fl  = os.path.join(drc_output, fl_label)
+            if not self.eventDocument and os.path.exists(path_fl):
+                print("{path_fl} is loaded. Existing labels can be modified and added. ".format(path_fl = path_fl))
+                with open(path_fl, 'r') as fh:
+                    self.eventDocument = json.load(fh)
+                    print(self.eventDocument)
+
             if type(event) == QtGui.QKeyEvent:
                 # Enable viewing thresholded event only
                 if event.key() == QtCore.Qt.Key_T:
@@ -202,8 +214,7 @@ class Window(QtGui.QMainWindow):
                     # Process the OK event
                     if is_ok:
                         # Record the label
-                        self.eventDocument[int(ex.eventNumber)] = label_str
-                        ## print(self.eventDocument)
+                        self.eventDocument[ex.eventNumber] = label_str
 
                         # Report it to terminal
                         record = "{experimentName}.{runNumber:04d}.{eventNumber:06d}".format( experimentName = ex.experimentName,

--- a/psocake/gui.py
+++ b/psocake/gui.py
@@ -164,11 +164,13 @@ class Window(QtGui.QMainWindow):
                                 end_rght = eventNumberFiltered[-1]
                                 event_filtered_dict[end_left]["prev"] = end_rght
                                 event_filtered_dict[end_rght]["next"] = end_left
+                            else:
+                                print("Warning!!! There is no images with label '{label_str}'.  ".format( label_str = label_str ))
 
-                                self.eventNumberView = eventNumberFiltered
-                                self.event_dict      = event_filtered_dict
+                            self.eventNumberView = eventNumberFiltered
+                            self.event_dict      = event_filtered_dict
                     else:
-                        print("Warning!!! There is no images with label '{label_str}'".format( label_str = label_str ))
+                        print("No label is found.  Please try it again.".format( label_str = label_str ))
 
                 # Define keystrokes for saving (experiment name, run, event) to a json file
                 if event.key() == QtCore.Qt.Key_S:


### PR DESCRIPTION
Supported inputs for SPI image labeling after psocake GUI is open:
- Key 0: No hit.
- Key 1: Single hit.
- Key 2: Multiple hits.
- Key 3: Unknown hits.
- Key 4: No hit (alias to Key 0, for keeping user's hand at key 1-4 area)
- Key s: Save a json file with the extension `.label.json`.

Json file format:
- Filename follows the convention: `{exp}.{run}.label.json`, such as
  `amo06516.0102.label.json`.
- If `{exp}.{run}.label.json` has existed, a backup file with a
  timestamp will be created automatically when `s` is pressed.
  Backup file has a filename following convention:
  `{exp}.{run}.{timestamp}.label.json.bak`, such as
  `amo06516.0102.20220113171435.label.json.bak`.
- File content consists of key value pairs -- `{eventNumber}:{label}`.