### PR TITLE
Fix ragged array-induced bug in displaying CXI peaks

### DIFF
--- a/psocake/PeakFindingPanel.py
+++ b/psocake/PeakFindingPanel.py
@@ -777,6 +777,7 @@ self.hitParam_algorithm2_str: 2,
         if len(self.iX.shape) == 2:
             self.iX = np.expand_dims(self.iX, axis=0)
             self.iY = np.expand_dims(self.iY, axis=0)
+
         cenX = self.iX[np.array(peaks[:, 0], dtype=np.int64), np.array(peaks[:, 1], dtype=np.int64), np.array(
             peaks[:, 2], dtype=np.int64)] + 0.5
         cenY = self.iY[np.array(peaks[:, 0], dtype=np.int64), np.array(peaks[:, 1], dtype=np.int64), np.array(
@@ -823,6 +824,7 @@ self.hitParam_algorithm2_str: 2,
             f.close()
             # Convert cheetah peaks to psana peaks
             s, r, c = self.parent.detDesc.convert_peaks_to_psana(row2d, col2d)
+            if not isinstance(s, list): s = np.full(len(r), s)
             peaks = np.array([s, r, c]).T
             # Display peaks
             if peaks is not None and len(peaks) > 0:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<psocake_path>/PeakFindingPanel.py", line 323, in change
    self.paramUpdate(path, change, data)
  File "<psocake_path>/PeakFindingPanel.py", line 336, in paramUpdate
    self.updateClassification()
  File "<psocake_path>/PeakFindingPanel.py", line 555, in updateClassification
    self.drawPeaks()
  File "<psocake_path>/PeakFindingPanel.py", line 830, in drawPeaks
    cenX, cenY = self.assemblePeakPos(peaks)
  File "<psocake_path>/PeakFindingPanel.py", line 780, in assemblePeakPos
    cenX = self.iX[np.array(peaks[:, 0], dtype=np.int64), np.array(peaks[:, 1], dtype=np.int64), np.array(
IndexError: too many indices for array: array is 1-dimensional, but 2 were indexed
<psocake_path>/PeakFindingPanel.py:826: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
```