### PR TITLE
Port `psocake` to S3DF.

### DIFF
--- a/psocake/CrystalIndexingPanel.py
+++ b/psocake/CrystalIndexingPanel.py
@@ -118,7 +118,7 @@ class CrystalIndexing(object):
                                                                     self.parent.pk.hitParam_psnehprioq_str: 'psnehprioq',
                                                                     self.parent.pk.hitParam_psfehq_str: 'psfehq',
                                                                     self.parent.pk.hitParam_psnehq_str: 'psnehq',
-                                                                    self.parent.pk.hitParam_psanaq_str: 'psanaq',
+                                                                    self.parent.pk.hitParam_psanaq_str: 'milano',
                                                                     self.parent.pk.hitParam_psdebugq_str: 'psdebugq',
                                                                     self.parent.pk.hitParam_psanagpuq_str: 'psanagpuq',
                                                                     self.parent.pk.hitParam_psanaidleq_str: 'psanaidleq',

--- a/psocake/PeakFindingPanel.py
+++ b/psocake/PeakFindingPanel.py
@@ -69,7 +69,7 @@ class PeakFinding:
         self.hitParam_runs_str = 'Run(s)'
         self.hitParam_queue_str = 'queue'
         self.hitParam_cpu_str = 'CPUs'
-        self.hitParam_psanaq_str = 'psanaq'
+        self.hitParam_psanaq_str = 'milano'
         self.hitParam_psnehq_str = 'psnehq'
         self.hitParam_psfehq_str = 'psfehq'
         self.hitParam_psnehprioq_str = 'psnehprioq'
@@ -191,7 +191,7 @@ self.hitParam_algorithm2_str: 2,
                                                                              self.hitParam_psnehprioq_str: 'psnehprioq',
                                                                              self.hitParam_psfehq_str: 'psfehq',
                                                                              self.hitParam_psnehq_str: 'psnehq',
-                                                                             self.hitParam_psanaq_str: 'psanaq',
+                                                                             self.hitParam_psanaq_str: 'milano',
                                                                              self.hitParam_psdebugq_str: 'psdebugq',
                                                                              self.hitParam_psanagpuq_str: 'psanagpuq',
                                                                              self.hitParam_psanaidleq_str: 'psanaidleq',

--- a/psocake/gui.py
+++ b/psocake/gui.py
@@ -109,6 +109,11 @@ class MainFrame(QtWidgets.QWidget):
             self.dir = '/reg/d/psdm'
             if "ffb" in args.access.lower():
                 self.dir = '/cds/data/drpsrcf'
+        elif 'S3DF' in os.environ['PSOCAKE_FACILITY'].upper():
+            self.facility = self.facilityLCLS
+            self.dir = '/sdf/data/lcls/ds/'
+            if "ffb" in args.access.lower():
+                self.dir = '/sdf/data/lcls/drpsrcf'
 
         # Init experiment parameters from args
         if args.expRun is not None and ':run=' in args.expRun:

--- a/psocake/indexCrystals.py
+++ b/psocake/indexCrystals.py
@@ -348,7 +348,7 @@ for rank in range(numWorkers):
     if batch == "lsf":
         cmd += " --temp-dir=/scratch"
     else:
-        cmd += " --temp-dir=/u1"
+        cmd += " --temp-dir=tmp"
     cmd += " --tolerance=" + tolerance + \
            " --no-revalidate --multi --profile"
     if pdb: cmd += " --pdb=" + pdb


### PR DESCRIPTION
Need the following files (let's call it `setup-sh`) to run crystfel.

```
CFDIR=/sdf/group/lcls/ds/tools/crystfel/0.10.2

export CLIBD=/sdf/group/lcls/ds/tools/ccp4-8.0/lib/data
export CINCL=/sdf/group/lcls/ds/tools/ccp4-8.0/include
export CCP4_SCR=/tmp

export PATH=${CFDIR} /bin:$PATH
export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:${CFDIR}/lib/pkgconfig
export LD_RUN_PATH=$LD_RUN_PATH: ${CFDIR} /lib
```

Moreover, run the following wrapper function to use `psocake` on s3df.

```
function psocake3.start ()
{
    echo 'Loading psocake3...'
    export PATH="/sdf/home/c/cwang31/codes/psocake/app:$PATH"
    export PYTHONPATH="/sdf/home/c/cwang31/codes/psocake:$PYTHONPATH"

    # CrystFEL
    source "PATH TO THE ABOVE setup-sh FILE"   # <--- Use a real path to the setup-sh file

    # CCP4
    source /sdf/group/lcls/ds/tools/ccp4-8.0/bin/ccp4.setup-sh

    # XDS
    export PATH=/sdf/group/lcls/ds/tools/XDS-INTEL64_Linux_x86_64:$PATH
}
```